### PR TITLE
expose listCollections on native driver as db.list() api

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,11 +147,11 @@ Returns a thunk which when executed deletes the entire database.
 yield db.drop();
 ```
 
-#### list
+#### listCollections
 Returns a thunk which when executed list existing collections in the database.
 
 ```js
-yield db.list();
+yield db.listCollections();
 ```
 
 #### ping

--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ Returns a thunk which when executed deletes the entire database.
 yield db.drop();
 ```
 
+#### list
+Returns a thunk which when executed list existing collections in the database.
+
+```js
+yield db.list();
+```
+
 #### ping
 Returns a thunk which when executed sends a to database.
 

--- a/db.js
+++ b/db.js
@@ -65,6 +65,21 @@ Db.prototype.drop = function() {
 }
 
 /**
+ * Returns a thunk which when executed
+ * list existing collections in the database.
+ *
+ *     yield db.list();
+ *
+ * @returns {Function} thunk
+ * @api public
+ */
+
+Db.prototype.list = function() {
+  debug('list()');
+  return this.db.listCollections.bind(this.db);
+}
+
+/**
  * Creates a new collection object for the given `name`.
  *
  *     var Trends = db.col('trends');

--- a/db.js
+++ b/db.js
@@ -68,14 +68,14 @@ Db.prototype.drop = function() {
  * Returns a thunk which when executed
  * list existing collections in the database.
  *
- *     yield db.list();
+ *     yield db.listCollections();
  *
  * @returns {Function} thunk
  * @api public
  */
 
-Db.prototype.list = function() {
-  debug('list()');
+Db.prototype.listCollections = function() {
+  debug('listCollections()');
   return this.db.listCollections.bind(this.db);
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ var m = require('../');
 require('co-mocha');
 
 // default test database
-var uri = process.env.YIELDB_TEST_URI || 'mongodb://localhost/yieldb_test';
+var uri = process.env.YIELDB_TEST_URI;
 if (!('string' == typeof uri && uri.length)) {
   throw new Error('Missing YIELDB_TEST_URI environment variable');
 }
@@ -1015,9 +1015,9 @@ describe('yieldb', function() {
       });
     });
 
-    describe('list()', function() {
+    describe('listCollections()', function() {
       it('returns a thunk', function*() {
-        assert('function', typeof db.list());
+        assert('function', typeof db.listCollections());
       });
 
       it('list collection names', function*() {
@@ -1026,7 +1026,7 @@ describe('yieldb', function() {
         var X = db.col('x');
         yield [ X.insert({ pebble: true }) ];
 
-        var names = yield db.list();
+        var names = yield db.listCollections();
         yield X.drop();
 
         assert.equal(2, names.length);

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,7 @@ var m = require('../');
 require('co-mocha');
 
 // default test database
-var uri = process.env.YIELDB_TEST_URI;
+var uri = process.env.YIELDB_TEST_URI || 'mongodb://localhost/yieldb_test';
 if (!('string' == typeof uri && uri.length)) {
   throw new Error('Missing YIELDB_TEST_URI environment variable');
 }
@@ -1012,6 +1012,28 @@ describe('yieldb', function() {
         var user = db.col(name);
         assert(user instanceof m.Collection);
         assert.equal(name, user.name);
+      });
+    });
+
+    describe('list()', function() {
+      it('returns a thunk', function*() {
+        assert('function', typeof db.list());
+      });
+
+      it('list collection names', function*() {
+        var db = yield m.connect(uri);
+
+        var X = db.col('x');
+        yield [ X.insert({ pebble: true }) ];
+
+        var names = yield db.list();
+        yield X.drop();
+
+        assert.equal(2, names.length);
+        names = names.map(function(col) {
+          return col.name.replace(db.db.databaseName + '.', '');
+        }).sort();
+        assert.deepEqual(['system.indexes', 'x'], names);
       });
     });
 


### PR DESCRIPTION
We find it quite handy in some cases (such as db admin console).

Though in terms of yieldb, I think native listCollections result sucks, see test case on our preferred output (a plain array of collection names without db name prefix). But it maybe dangerous to deviate from native driver output, so I left it like other api.