### PR TITLE
dropIndex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,15 @@ Returns a yieldable promise.
 yield db.col('watches').index(indexDefinition, options);
 ```
 
+#### dropIndex
+
+Drops an index.
+Returns a yieldable promise.
+
+```js
+yield db.col('watches').dropIndex(indexDefinition, options);
+```
+
 #### indexes
 
 Retreives an array of all defined indexes for this collection.

--- a/collection.js
+++ b/collection.js
@@ -370,6 +370,43 @@ Collection.prototype.index = function(def, opts) {
 }
 
 /**
+ * Drop an index
+ *
+ *     var User = db.col('users');
+ *     yield User.dropIndex('name_1_email_-1');
+ *     yield User.dropIndex({ name: 1, email: -1 });
+ *
+ * @param {String|Object} indexDefinition
+ * @param {Object} [options]
+ * @returns {Promise/Function} promise
+ */
+
+Collection.prototype.dropIndex = function(def, opts) {
+  if (!def) throw new TypeError('missing index definition');
+
+  var defString = '';
+  if (typeof def === 'object') {
+    for (var prop in def) {
+      defString += prop + '_' + def[prop].toString() + '_';
+    }
+    defString = defString.slice(0, -1);
+  } else {
+    defString = def;
+  }
+
+  opts || (opts = {});
+  var self = this;
+
+  function index(cb) {
+    debug('%s.index(%j, %j)', self.name, defString, opts);
+    self.col.dropIndex(defString, opts, cb);
+  }
+
+  index.then = helper.makeThen(index);
+  return index;
+}
+
+/**
  * Retreives all indexes for the given collection
  *
  *     var User = db.col('users');

--- a/test/index.js
+++ b/test/index.js
@@ -1083,6 +1083,60 @@ describe('yieldb', function() {
       });
     });
 
+    describe('#dropIndex()', function() {
+      it('returns a thunk', function(done) {
+        var fn = User.dropIndex({ name: 1 });
+        assert.equal('function', typeof fn);
+        done();
+      });
+
+      it('returns a promise', function(done) {
+        var p = User.dropIndex({ x: 1 });
+        p.then(win, done);
+        function win(res) {
+          assert(res);
+          done();
+        }
+      });
+
+      it('requires an index definition', function(done) {
+        assert.throws(function() {
+          User.dropIndex();
+        }, /missing/);
+        done();
+      });
+
+      it('accepts string input', function*() {
+        var name = 'qwertyui';
+        var def = {};
+        def[name] = 1;
+
+        var res = yield User.index(def, { sparse: true });
+        var info = yield User.indexes();
+        assert.equal(3, info.length);
+
+        var indexDefString = name + '_1';
+        var res = yield User.dropIndex(indexDefString);
+        var info = yield User.indexes();
+        assert.equal(2, info.length);
+      });
+
+      it('accepts object input', function*() {
+        var name = 'asdfghjk';
+        var def = {};
+        def[name] = 1;
+
+        var res = yield User.index(def, { sparse: true });
+        var info = yield User.indexes();
+        assert.equal(3, info.length);
+
+        var indexDefObject = def;
+        var res = yield User.dropIndex(indexDefObject);
+        var info = yield User.indexes();
+        assert.equal(2, info.length);
+      });
+    });
+
     describe('#where()', function() {
       it('returns an mquery', function(done) {
         var query = User.where('x');


### PR DESCRIPTION
As discussed in #13 

Worth noting the mongodb driver only take `name` as input, I made it so that both index definition (object) and name string are supported.